### PR TITLE
Add Critters 3D safari demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,580 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>Critters 3D — React + Three.js (Fixed)</title>
+
+  <!-- Tailwind (CDN) -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root{
+      --bg:#0b1021; --bg2:#0f1430; --panel:#161b37; --panel2:#1d2450; --ink:#e8ebff; --muted:#b6bfda;
+      --accent:#8c7ae6; --good:#39e18e; --warn:#ffd166; --bad:#ff5d5d;
+    }
+    html,body{height:100%}
+    body{
+      margin:0; font-family: ui-sans-serif,system-ui,Inter,Segoe UI,Roboto,Helvetica,Arial;
+      color:var(--ink);
+      background:
+        radial-gradient(1200px 800px at 10% -10%, #1b2250 0%, transparent 60%),
+        radial-gradient(1200px 900px at 120% 0%, #151a3a 0%, transparent 55%),
+        linear-gradient(180deg, var(--bg), var(--bg2));
+      background-attachment: fixed;
+    }
+    .card{background:linear-gradient(180deg,rgba(255,255,255,.03),rgba(255,255,255,.01)), var(--panel); border:1px solid rgba(255,255,255,.07); border-radius:14px}
+    .btn{border:1px solid rgba(255,255,255,.1); border-radius:10px; padding:.55rem .8rem; font-weight:700}
+    .btn-ghost{background:linear-gradient(180deg,#26304f,#18203a); color:white}
+    .btn-primary{background:linear-gradient(180deg,#5b56cc,#3a3691); color:white}
+    .btn-danger{background:linear-gradient(180deg,#8b2f2f,#5a1d1d); color:white}
+    .meter{position:relative; height:12px; background:#101429; border:1px solid rgba(255,255,255,.08); border-radius:999px; overflow:hidden}
+    .meter>i{position:absolute; inset:0; width:0%; background:linear-gradient(90deg,#5b56cc,#6c67e8,#9a7bf0)}
+    .modal{position:fixed; inset:0; background:rgba(9,12,25,.7); display:flex; align-items:center; justify-content:center; z-index:50}
+    .canvas-wrap{position:relative; width:100%; aspect-ratio: 16/10; max-height: 70vh; border:2px solid var(--accent); border-radius:12px; overflow:hidden; box-shadow:0 0 0 1px rgba(255,255,255,.04), 0 10px 24px rgba(0,0,0,.45)}
+    canvas{display:block; width:100%; height:100%}
+  </style>
+
+  <!-- React 18 (UMD) + Babel for JSX -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <!-- Three.js r128 + OrbitControls (UMD-compatible examples/js) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/js/controls/OrbitControls.min.js"></script>
+</head>
+<body>
+  <div id="root" class="min-h-full p-4 sm:p-6 flex items-start justify-center"></div>
+
+  <!-- Our app (compiled by Babel in the browser) -->
+  <script type="text/babel" data-presets="env,react">
+  const {useState,useEffect,useRef,useMemo} = React;
+
+  const TILE = { WALL:0, FLOOR:1, GOLD:2, ENEMY:3, TRAP:4 };
+  const MAP_W=15, MAP_H=15;
+  const SAFARI_SCANS=10;
+
+  const XP_THRESHOLDS = {1:0,2:100,3:250,4:500,5:1000};
+  function levelFromXP(xp){
+    let lvl=1; for (const k of Object.keys(XP_THRESHOLDS).map(Number).sort((a,b)=>a-b)){ if (xp>=XP_THRESHOLDS[k]) lvl=k; else break; } return lvl;
+  }
+  const rnd = n => Math.floor(Math.random()*n);
+
+  function makeMap(){
+    const m = Array.from({length:MAP_H},()=>Array(MAP_W).fill(TILE.FLOOR));
+    for(let i=0;i<MAP_W*MAP_H*0.06;i++) m[rnd(MAP_H)][rnd(MAP_W)] = TILE.WALL;
+    for(let i=0;i<MAP_W*MAP_H*0.04;i++){ let x,y; do{ x=rnd(MAP_W); y=rnd(MAP_H);}while(m[y][x]!==TILE.FLOOR); m[y][x]=TILE.GOLD; }
+    for(let i=0;i<MAP_W*MAP_H*0.05;i++){ let x,y; do{ x=rnd(MAP_W); y=rnd(MAP_H);}while(m[y][x]!==TILE.FLOOR); m[y][x]=TILE.ENEMY; }
+    for(let i=0;i<MAP_W*MAP_H*0.03;i++){ let x,y; do{ x=rnd(MAP_W); y=rnd(MAP_H);}while(m[y][x]!==TILE.FLOOR); m[y][x]=TILE.TRAP; }
+    return m;
+  }
+
+  function randomCritter(env="Forest"){
+    const pool = ({
+      Forest:["Organic","Bug","Mystic","Energy"],
+      Cave:["Elemental","Gemstone","Spirit"],
+      "Sandy Beach":["Aquatic","Bird","Organic"],
+      "Urban Setting":["Mechanical","Robot","Electric"],
+      "Solar Wind Farm":["Electric","Energy","Cosmic","Solar"]
+    })[env] || ["Organic"];
+    const type = pool[rnd(pool.length)];
+    const strength = 10 + rnd(91);
+    const names = ["Zintle","Korbi","Arclume","Glimbug","Petripup","Vaporling","Hexfin","Skitters","Sunwisp","Cairnix","Voltlet","Myrmist"];
+    const name = names[rnd(names.length)];
+    const description = `A ${type.toLowerCase()} critter native to ${env}, bristling with ${strength}-grade moxie.`;
+    return { id:crypto.randomUUID(), name, type, strength, description };
+  }
+
+  const Pill = ({label,value}) => (
+    <div className="px-3 py-2 rounded-lg border border-white/10 bg-[var(--panel2)] text-sm font-semibold">
+      <span className="text-[var(--muted)] mr-1">{label}:</span><span className="text-sky-200">{value}</span>
+    </div>
+  );
+
+  const Meter = ({ratio}) => (
+    <div className="meter"><i style={{width:`${Math.max(0,Math.min(1,ratio))*100}%`}}></i></div>
+  );
+
+  const Modal = ({title,children,onClose,wide=false}) => (
+    <div className="modal">
+      <div className={`card p-4 w-[min(92vw,${wide? '900px':'700px'})]`}>
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-xl font-extrabold">{title}</h2>
+          <button className="btn btn-ghost" onClick={onClose}>Close</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+
+  function Scene3D({map, tilt=-0.7, onTilePick}){
+    const wrapRef = useRef(null);
+    const rendererRef = useRef(null);
+    const sceneRef = useRef(new THREE.Scene());
+    const cameraRef = useRef(null);
+    const controlsRef = useRef(null);
+    const raycasterRef = useRef(new THREE.Raycaster());
+    const pointer = useRef(new THREE.Vector2());
+
+    const tilesRef = useRef([]);
+
+    useEffect(()=>{
+      const wrap = wrapRef.current;
+      const scene = sceneRef.current;
+      scene.clear();
+
+      const rect = wrap.getBoundingClientRect();
+      const aspect = rect.width/rect.height;
+      const camera = new THREE.PerspectiveCamera(55, aspect, 0.1, 1000);
+      camera.position.set(10, 16, 18);
+      camera.lookAt(0,0,0);
+      cameraRef.current = camera;
+
+      const renderer = new THREE.WebGLRenderer({antialias:true, alpha:true});
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio,2));
+      renderer.setSize(rect.width, rect.height);
+      wrap.innerHTML='';
+      wrap.appendChild(renderer.domElement);
+      rendererRef.current = renderer;
+
+      const controls = new THREE.OrbitControls(camera, renderer.domElement);
+      controls.enableDamping = true;
+      controls.minDistance = 8; controls.maxDistance = 45;
+      controls.target.set(MAP_W*0.5, 0, MAP_H*0.5);
+      controlsRef.current = controls;
+
+      const hem = new THREE.HemisphereLight(0xaad0ff, 0x0b0f20, 0.8);
+      scene.add(hem);
+      const dir = new THREE.DirectionalLight(0xffffff, 0.9);
+      dir.position.set(8,18,10);
+      dir.castShadow = true;
+      scene.add(dir);
+
+      const base = new THREE.Mesh(
+        new THREE.PlaneGeometry(MAP_W+2, MAP_H+2),
+        new THREE.MeshStandardMaterial({color:0x0e1329, roughness:1, metalness:0})
+      );
+      base.rotation.x = -Math.PI/2;
+      base.position.set(MAP_W/2, -0.01, MAP_H/2);
+      base.receiveShadow = true;
+      scene.add(base);
+
+      const board = new THREE.Group();
+      board.rotation.x = tilt;
+      board.position.y = 0.0;
+      scene.add(board);
+
+      tilesRef.current = [];
+      const tileGeo = new THREE.BoxGeometry(0.92, 0.2, 0.92);
+      const matFloor = new THREE.MeshStandardMaterial({color:0x1c2248});
+      const matWall  = new THREE.MeshStandardMaterial({color:0x2a2f63});
+      const matGold  = new THREE.MeshStandardMaterial({color:0xffd166, emissive:0x553300, emissiveIntensity:0.3});
+      const matEnemy = new THREE.MeshStandardMaterial({color:0xff5d5d, emissive:0x330000, emissiveIntensity:0.3});
+      const matTrap  = new THREE.MeshStandardMaterial({color:0x8c7ae6, emissive:0x221144, emissiveIntensity:0.3});
+
+      for(let y=0;y<MAP_H;y++){
+        for(let x=0;x<MAP_W;x++){
+          const t = map[y][x];
+          let mat = matFloor, h=0.2;
+          if (t===TILE.WALL){ mat=matWall; h=0.9; }
+          if (t===TILE.GOLD){ mat=matGold; h=0.25; }
+          if (t===TILE.ENEMY){ mat=matEnemy; h=0.25; }
+          if (t===TILE.TRAP){ mat=matTrap; h=0.18; }
+          const mesh = new THREE.Mesh(tileGeo, mat);
+          mesh.castShadow = true; mesh.receiveShadow = true;
+          mesh.scale.y = h/0.2;
+          mesh.position.set(x, h/2, y);
+          mesh.userData = {x,y,tile:t};
+          board.add(mesh);
+          tilesRef.current.push(mesh);
+
+          if (t===TILE.ENEMY){
+            const gem = new THREE.Mesh(new THREE.OctahedronGeometry(0.18,0),
+              new THREE.MeshStandardMaterial({color:0xdd3333, metalness:0.2, roughness:0.5, emissive:0x220000, emissiveIntensity:0.25}));
+            gem.position.set(0, 0.35, 0);
+            gem.userData.kind='marker';
+            mesh.add(gem);
+          }
+          if (t===TILE.TRAP){
+            const ring = new THREE.Mesh(new THREE.TorusGeometry(0.28,0.03,8,24),
+              new THREE.MeshStandardMaterial({color:0x8c7ae6, emissive:0x221155, emissiveIntensity:0.35}));
+            ring.rotation.x = Math.PI/2;
+            ring.position.y = 0.11;
+            ring.userData.kind='marker';
+            mesh.add(ring);
+          }
+          if (t===TILE.GOLD){
+            const nug = new THREE.Mesh(new THREE.DodecahedronGeometry(0.16),
+              new THREE.MeshStandardMaterial({color:0xffe08a, metalness:0.6, roughness:0.2, emissive:0x332200, emissiveIntensity:0.25}));
+            nug.position.y = 0.28;
+            nug.userData.kind='marker';
+            mesh.add(nug);
+          }
+        }
+      }
+
+      let stop=false;
+      const clock = new THREE.Clock();
+      function animate(){
+        if (stop) return;
+        requestAnimationFrame(animate);
+        const t = clock.getElapsedTime();
+        tilesRef.current.forEach(m=>{
+          if (!m.children || !m.children.length) return;
+          m.children.forEach(ch=>{
+            if (ch.userData.kind==='marker'){
+              ch.position.y = 0.25 + Math.sin(t*2 + m.position.x*0.2 + m.position.z*0.2)*0.05;
+              ch.rotation.y += 0.01;
+            }
+          });
+        });
+        controls.update();
+        renderer.render(scene, camera);
+      }
+      animate();
+
+      const onResize=()=>{
+        const r = wrap.getBoundingClientRect();
+        renderer.setSize(r.width, r.height);
+        camera.aspect = r.width/r.height;
+        camera.updateProjectionMatrix();
+      };
+      window.addEventListener('resize', onResize);
+
+      const onPointer = (evt)=>{
+        const rect = renderer.domElement.getBoundingClientRect();
+        const x = ((evt.clientX - rect.left) / rect.width) * 2 - 1;
+        const y = -((evt.clientY - rect.top) / rect.height) * 2 + 1;
+        pointer.current.set(x,y);
+        raycasterRef.current.setFromCamera(pointer.current, camera);
+        const intersects = raycasterRef.current.intersectObjects(tilesRef.current, false);
+        if (intersects.length){
+          const obj = intersects[0].object;
+          const {x,y,tile} = obj.userData;
+          obj.scale.y *= 1.2;
+          setTimeout(()=>{ obj.scale.y /= 1.2; }, 120);
+          onTilePick && onTilePick({x,y,tile});
+        }
+      };
+      renderer.domElement.addEventListener('pointerdown', onPointer);
+
+      return ()=>{
+        stop=true;
+        window.removeEventListener('resize', onResize);
+        renderer.domElement.removeEventListener('pointerdown', onPointer);
+        controls.dispose();
+        renderer.dispose();
+      };
+    },[map, tilt]);
+
+    return <div ref={wrapRef} className="canvas-wrap" aria-label="3D Safari Board"></div>;
+  }
+
+  function SafariSelect({level, onPick, onClose}){
+    const LOCS=[
+      {name:"Forest", req:1, blurb:"Organic, Bug, Mystic"},
+      {name:"Cave", req:2, blurb:"Elemental, Gemstone, Spirit"},
+      {name:"Sandy Beach", req:3, blurb:"Aquatic, Bird"},
+      {name:"Urban Setting", req:4, blurb:"Mechanical, Robot, Electric"},
+      {name:"Solar Wind Farm", req:5, blurb:"Electric, Energy, Cosmic"}
+    ];
+    return (
+      <Modal title="Choose Safari Location" onClose={onClose}>
+        <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-3">
+          {LOCS.map(l=>{
+            const locked = level<l.req;
+            return (
+              <button key={l.name}
+                className={`card p-3 text-left ${locked?'opacity-60 cursor-not-allowed':'hover:ring-2 hover:ring-[var(--accent)]'}`}
+                disabled={locked}
+                onClick={()=>onPick(l.name)}>
+                <div className="flex items-center justify-between">
+                  <h3 className="font-extrabold">{l.name}</h3>
+                  <span className="text-xs text-[var(--muted)]">Lv {l.req}+</span>
+                </div>
+                <div className="text-sm text-[var(--muted)] mt-1">Common: {l.blurb}</div>
+              </button>
+            );
+          })}
+        </div>
+      </Modal>
+    );
+  }
+
+  function BattleModal({you,foe,log,onAttack,onRun}){
+    const ratioYou = you.hp/you.maxHp;
+    const ratioFoe = foe.hp/foe.maxHp;
+    return (
+      <Modal title="Encounter!" onClose={onRun}>
+        <div className="grid sm:grid-cols-2 gap-4">
+          <div className="card p-3">
+            <div className="text-sm text-[var(--muted)]">You</div>
+            <div className="meter"><i style={{width:`${Math.max(0,Math.min(1,ratioYou))*100}%`}}></i></div>
+            <div className="mt-1 text-sm">{Math.max(0,Math.round(you.hp))}/{you.maxHp}</div>
+          </div>
+          <div className="card p-3">
+            <div className="text-sm text-[var(--muted)]">Wild {foe.critter.name}</div>
+            <div className="meter"><i style={{width:`${Math.max(0,Math.min(1,ratioFoe))*100}%`}}></i></div>
+            <div className="mt-1 text-sm">{Math.max(0,Math.round(foe.hp))}/{foe.maxHp}</div>
+          </div>
+        </div>
+        <div className="text-center my-3 text-lg">{foe.critter.type} • STR {foe.critter.strength}</div>
+        <div className="card p-3 h-32 overflow-auto text-sm text-[var(--muted)]">
+          {log.slice(-8).map((l,i)=><p key={i} className="mb-1">{l}</p>)}
+        </div>
+        <div className="flex gap-2 justify-center mt-3">
+          <button className="btn btn-danger" onClick={onAttack}>Attack</button>
+          <button className="btn btn-ghost" onClick={onRun}>Run</button>
+        </div>
+      </Modal>
+    );
+  }
+
+  function CollectionModal({items, leadId, setLead, onRelease, onClose}){
+    return (
+      <Modal title={`Your Critter Collection (${items.length})`} onClose={onClose} wide>
+        <div className="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+          {items.length===0 && <div className="text-[var(--muted)]">No critters yet.</div>}
+          {items.map(c=>(
+            <div key={c.id} className="card p-3">
+              <div className="flex items-center justify-between">
+                <h3 className="font-bold">{c.name}</h3>
+                <span className="text-xs text-[var(--muted)]">{c.type}</span>
+              </div>
+              <div className="text-sm text-[var(--muted)]">STR {c.strength}</div>
+              <p className="text-sm mt-1">{c.description}</p>
+              <div className="flex gap-2 mt-2">
+                <button className={`btn ${leadId===c.id?'btn-primary':'btn-ghost'}`} onClick={()=>setLead(c.id)}>
+                  {leadId===c.id?'Lead':'Set Lead'}
+                </button>
+                <button className="btn btn-ghost" onClick={()=>onRelease(c.id)}>Release</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Modal>
+    );
+  }
+
+  function App(){
+    const [xp,setXP]=useState(0);
+    const level = useMemo(()=>levelFromXP(xp),[xp]);
+    const [energy,setEnergy]=useState(50);
+    const [hp,setHP]=useState(100);
+
+    const [coll,setColl]=useState([]);
+    const [leadId,setLeadId]=useState(null);
+    const lead = useMemo(()=>coll.find(c=>c.id===leadId)||null,[coll,leadId]);
+
+    const [log,setLog]=useState(["Welcome to the 3D Critter Lab. Choose a Safari to begin."]);
+    const pushLog = (m)=>setLog(l=>[m,...l].slice(0,40));
+
+    const [map,setMap]=useState(makeMap());
+    const [location,setLocation]=useState(null);
+    const [scans,setScans]=useState(SAFARI_SCANS);
+    const [inSafari,setInSafari]=useState(false);
+
+    const [showSelect,setShowSelect]=useState(false);
+    const [showCollection,setShowCollection]=useState(false);
+    const [battle,setBattle]=useState(null);
+
+    const startSafari = (loc)=>{
+      setLocation(loc);
+      setMap(makeMap());
+      setScans(SAFARI_SCANS);
+      setInSafari(true);
+      setShowSelect(false);
+      pushLog(`Entered ${loc}. Scans: ${SAFARI_SCANS}. Click tiles.`);
+    };
+    const endSafari = (reason="manual")=>{
+      setInSafari(false);
+      setLocation(null);
+      setScans(SAFARI_SCANS);
+      if (reason==="dead") pushLog("Defeated in battle. Returning to Lab.");
+      else if (reason==="deadzone") pushLog("Dead Zone encountered. Returning to Lab.");
+      else pushLog("Safari ended. Back to Lab.");
+    };
+
+    const onTilePick = ({x,y,tile})=>{
+      if (!inSafari) return;
+      if (scans<=0){ endSafari("complete"); return; }
+      setScans(s=>s-1);
+
+      setMap(m=>{
+        const copy = m.map(row=>row.slice());
+        const t = copy[y][x];
+        copy[y][x] = TILE.FLOOR;
+
+        if (t===TILE.WALL){
+          pushLog("A wall. Nothing to see.");
+          setXP(v=>v+1);
+        } else if (t===TILE.FLOOR){
+          pushLog("Scanned area. No notable signals.");
+          setXP(v=>v+1);
+        } else if (t===TILE.GOLD){
+          setEnergy(v=>v+15);
+          setXP(v=>v+5);
+          pushLog("Found energy cache: +15 Energy.");
+        } else if (t===TILE.TRAP){
+          pushLog("Dead Zone: connection lost.");
+          endSafari("deadzone");
+        } else if (t===TILE.ENEMY){
+          const crit = randomCritter(location||"Forest");
+          const youMax = lead ? Math.max(50, 50 + lead.strength) : 100;
+          const you = {hp:youMax, maxHp:youMax, atkMin:10+(lead? Math.floor(lead.strength/6):0), atkMax:20+(lead? Math.floor(lead.strength/3):0)};
+          const foeMax = Math.round(crit.strength*1.5);
+          const foe = {hp:foeMax, maxHp:foeMax, critter:crit};
+          setBattle({you,foe,log:[`A wild ${crit.name} appears! (STR ${crit.strength})`]});
+        }
+        return copy;
+      });
+    };
+
+    const battleAttack = ()=>{
+      setBattle(b=>{
+        if (!b) return b;
+        const youHit = b.you.atkMin + rnd(b.you.atkMax-b.you.atkMin+1);
+        const foeHit = Math.round(b.foe.critter.strength * (0.4 + Math.random()*0.4));
+        let foeHP = Math.max(0, b.foe.hp - youHit);
+        let youHP = b.you.hp;
+        const lines = [`You hit ${b.foe.critter.name} for ${youHit}.`];
+        if (foeHP>0){
+          youHP = Math.max(0, youHP - foeHit);
+          lines.push(`${b.foe.critter.name} hits you for ${foeHit}.`);
+        }
+        const nb = {...b, you:{...b.you, hp:youHP}, foe:{...b.foe, hp:foeHP}, log:[...b.log, ...lines]};
+        if (foeHP<=0){
+          const captured = {...b.foe.critter, id:crypto.randomUUID()};
+          setColl(list=>[captured, ...list]);
+          setXP(v=>v+20);
+          pushLog(`Captured ${captured.name}! (+20 XP)`);
+          setBattle(null);
+        } else if (youHP<=0){
+          setHP(100);
+          pushLog("You were defeated!");
+          setBattle(null);
+          endSafari("dead");
+        }
+        if (lead){
+          setColl(list=>{
+            const copy = list.map(x=>({...x}));
+            const idx = copy.findIndex(x=>x.id===lead.id);
+            if (idx>=0){
+              const hpMax = lead.hpMax ?? (50+lead.strength);
+              copy[idx].hpMax = hpMax;
+              copy[idx].hp = Math.max(0, Math.min(hpMax, nb.you.hp));
+            }
+            return copy;
+          });
+        }
+        return nb;
+      });
+    };
+    const battleRun = ()=>{ setBattle(null); pushLog("You fled the encounter."); };
+
+    const setLead = (id)=> setLeadId(id);
+    const releaseCritter = (id)=> setColl(list=>list.filter(x=>x.id!==id));
+
+    return (
+      <div className="w-[min(1100px,96vw)]">
+        <header className="mb-3">
+          <h1 className="text-2xl font-black text-[var(--accent)]">Critters 3D — Pop-up Safari (Fixed)</h1>
+        </header>
+
+        <div className="card p-3 mb-3">
+          <div className="flex flex-wrap gap-2 items-center">
+            <Pill label="HP" value={hp} />
+            <Pill label="Energy" value={energy} />
+            <Pill label="XP" value={xp} />
+            <Pill label="Level" value={level} />
+            <Pill label="Lead" value={lead? `${lead.name} (${lead.hp??(lead.hpMax??(50+lead.strength))}/${lead.hpMax??(50+lead.strength)})` : "None"} />
+            <Pill label="Collected" value={coll.length} />
+            <div className="ml-auto flex gap-2">
+              {!inSafari ? (
+                <>
+                  <button className="btn btn-primary" onClick={()=>setShowSelect(true)}>Open Safari</button>
+                  <button className="btn btn-ghost" onClick={()=>setShowCollection(true)}>Collection</button>
+                  <button className="btn btn-ghost" onClick={()=>{
+                    const c = randomCritter("Forest"); setColl(l=>[c,...l]); pushLog(`Test critter added: ${c.name}`);
+                  }}>Add Test Critter</button>
+                </>
+              ) : (
+                <>
+                  <button className="btn btn-ghost" onClick={()=>endSafari("manual")}>End Safari</button>
+                  <button className="btn btn-ghost" onClick={()=>{ setMap(makeMap()); setScans(SAFARI_SCANS); pushLog("New scan grid prepared."); }}>New Grid</button>
+                </>
+              )}
+            </div>
+          </div>
+          <div className="mt-2">
+            <div className="text-xs text-[var(--muted)] mb-1">XP Progress</div>
+            <Meter ratio={(xp % (level*40)) / (level*40)} />
+          </div>
+        </div>
+
+        <div className="card p-3 mb-3">
+          <div className="text-sm text-[var(--muted)] mb-2">
+            {inSafari ? <>Location: <span className="text-sky-200">{location}</span> • Scans remaining: <span className="text-sky-200">{scans}</span></> : "You are in the Lab. Open Safari to explore."}
+          </div>
+          <Scene3D map={map} onTilePick={onTilePick} />
+        </div>
+
+        <div className="card p-3 max-h-[40vh] overflow-auto">
+          <h3 className="font-bold mb-2">Log</h3>
+          <div className="space-y-1 text-sm text-[var(--muted)]">
+            {log.map((l,i)=><p key={i}>{l}</p>)}
+          </div>
+        </div>
+
+        {showSelect && (
+          <SafariSelect
+            level={level}
+            onPick={(loc)=>{ startSafari(loc); }}
+            onClose={()=>setShowSelect(false)}
+          />
+        )}
+        {showCollection && (
+          <CollectionModal
+            items={coll}
+            leadId={leadId}
+            setLead={setLead}
+            onRelease={releaseCritter}
+            onClose={()=>setShowCollection(false)}
+          />
+        )}
+        {battle && (
+          <BattleModal
+            you={battle.you}
+            foe={battle.foe}
+            log={battle.log}
+            onAttack={battleAttack}
+            onRun={battleRun}
+          />
+        )}
+      </div>
+    );
+  }
+
+  const root = ReactDOM.createRoot(document.getElementById('root'));
+  root.render(<App />);
+  </script>
+
+  <script>
+    window.addEventListener('error', (e) => {
+      const pre = document.createElement('pre');
+      pre.style.position = 'fixed';
+      pre.style.bottom = '8px';
+      pre.style.left = '8px';
+      pre.style.padding = '8px 10px';
+      pre.style.background = 'rgba(0,0,0,.75)';
+      pre.style.color = 'white';
+      pre.style.maxWidth = '90vw';
+      pre.style.fontSize = '12px';
+      pre.style.whiteSpace = 'pre-wrap';
+      pre.style.zIndex = '9999';
+      pre.textContent = 'Error: ' + (e.error && e.error.stack ? e.error.stack : e.message);
+      document.body.appendChild(pre);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone HTML app showcasing the Critters 3D safari experience built with React, Three.js, and Tailwind
- include interactive safari board, battle encounters, and critter collection management

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_68cb470cfe608331bd5a015c4d2fc3ac)